### PR TITLE
fix(python314): replace deprecated `ast.NameConstant` with `ast.Constant`

### DIFF
--- a/flake8_datetimez.py
+++ b/flake8_datetimez.py
@@ -71,13 +71,13 @@ class DateTimeZVisitor(ast.NodeVisitor):
         if (is_datetime_class and node.func.attr == 'datetime') or is_unqualified_datetime_class_call:
             # ex `datetime(2000, 1, 1, 0, 0, 0, 0, datetime.timezone.utc)`
             is_case_1 = (len(node.args) == 8
-                            and not (isinstance(node.args[7], ast.NameConstant)
+                            and not (isinstance(node.args[7], ast.Constant)
                                     and node.args[7].value is None))
 
             # ex `datetime.datetime(2000, 1, 1, tzinfo=datetime.timezone.utc)`
             tzinfo_keyword = _get_from_keywords(node.keywords, 'tzinfo')
             is_case_2 = (tzinfo_keyword is not None
-                            and not (isinstance(tzinfo_keyword.value, ast.NameConstant)
+                            and not (isinstance(tzinfo_keyword.value, ast.Constant)
                                     and tzinfo_keyword.value.value is None))
 
             if not (is_case_1 or is_case_2):
@@ -97,13 +97,13 @@ class DateTimeZVisitor(ast.NodeVisitor):
                 # ex: `datetime.now(UTC)`
                 is_case_1 = (len(node.args) == 1
                              and len(node.keywords) == 0
-                             and not (isinstance(node.args[0], ast.NameConstant)
+                             and not (isinstance(node.args[0], ast.Constant)
                                       and node.args[0].value is None))
 
                 # ex: `datetime.now(tz=UTC)`
                 tz_keyword = _get_from_keywords(node.keywords, 'tz')
                 is_case_2 = (tz_keyword is not None
-                             and not (isinstance(tz_keyword.value, ast.NameConstant)
+                             and not (isinstance(tz_keyword.value, ast.Constant)
                                       and tz_keyword.value.value is None))
 
                 if not (is_case_1 or is_case_2):
@@ -113,13 +113,13 @@ class DateTimeZVisitor(ast.NodeVisitor):
                 # ex: `datetime.fromtimestamp(1234, UTC)`
                 is_case_1 = (len(node.args) == 2
                              and len(node.keywords) == 0
-                             and not (isinstance(node.args[1], ast.NameConstant)
+                             and not (isinstance(node.args[1], ast.Constant)
                                       and node.args[1].value is None))
 
                 # ex: `datetime.fromtimestamp(1234, tz=UTC)`
                 tz_keyword = _get_from_keywords(node.keywords, 'tz')
                 is_case_2 = (tz_keyword is not None
-                             and not (isinstance(tz_keyword.value, ast.NameConstant)
+                             and not (isinstance(tz_keyword.value, ast.Constant)
                                       and tz_keyword.value.value is None))
 
                 if not (is_case_1 or is_case_2):
@@ -138,7 +138,7 @@ class DateTimeZVisitor(ast.NodeVisitor):
                 else:
                     tzinfo_keyword = _get_from_keywords(pparent.keywords, 'tzinfo')
                     is_case_1 = (tzinfo_keyword is not None
-                                 and not (isinstance(tzinfo_keyword.value, ast.NameConstant)
+                                 and not (isinstance(tzinfo_keyword.value, ast.Constant)
                                           and tzinfo_keyword.value.value is None))
 
                 # ex: `datetime.strptime(...).astimezone()`


### PR DESCRIPTION
### 1. Summary

I fixed the critical problem due to which flake8-datetimez isn’t compatible with Python 3.14.

### 2. Details of the problem

#### 2.1. Deprecated syntax

[**The documentation of the `ast` module**](https://docs.python.org/3/library/ast.html#ast.AST.end_col_offset):

> *Changed in version 3.8*: Class `ast.Constant` is now used for all constants.
>
> *Deprecated since version 3.8*: Old classes `ast.Num`, `ast.Str`, `ast.Bytes`, `ast.NameConstant` and `ast.Ellipsis` are still available, but they will be removed in future Python releases. In the meantime, instantiating them will return an instance of a different class.

#### 2.2. The example of the problem fixing

[**scrapy#6463**](https://github.com/scrapy/scrapy/pull/6463)

The contributor of Scrapy [**just replaced `ast.NameConstant` with `ast.Constant`**](https://github.com/scrapy/scrapy/commit/5bbf8124ac6785b824b005ad1380039c963c2af1).

#### 2.3. Example file

`KiraExample.py`:

```python
from datetime import UTC, datetime

CURRENT_YEAR = datetime.now(tz=UTC).year

```

#### 2.4. Terminal commands

```python
pipenv --python 3.14

pipenv install --dev flake8 flake8-datetimez

pipenv run flake8 KiraExample.py
```

#### 2.5. Behavior

##### 2.5.1. Before the pull request

```python
D:\SashaDebugging\KiraFlake8Datetimez>pipenv run flake8 KiraExample.py
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "D:\SashaDebugging\KiraFlake8Datetimez\.venv\Scripts\flake8.EXE\__main__.py", line 7, in <module>
    sys.exit(main())
             ~~~~^^
  File "D:\SashaDebugging\KiraFlake8Datetimez\.venv\Lib\site-packages\flake8\main\cli.py", line 23, in main
    app.run(argv)
    ~~~~~~~^^^^^^
  File "D:\SashaDebugging\KiraFlake8Datetimez\.venv\Lib\site-packages\flake8\main\application.py", line 198, in run
    self._run(argv)
    ~~~~~~~~~^^^^^^
  File "D:\SashaDebugging\KiraFlake8Datetimez\.venv\Lib\site-packages\flake8\main\application.py", line 187, in _run
    self.run_checks()
    ~~~~~~~~~~~~~~~^^
  File "D:\SashaDebugging\KiraFlake8Datetimez\.venv\Lib\site-packages\flake8\main\application.py", line 103, in run_checks
    self.file_checker_manager.run()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "D:\SashaDebugging\KiraFlake8Datetimez\.venv\Lib\site-packages\flake8\checker.py", line 237, in run
    self.run_serial()
    ~~~~~~~~~~~~~~~^^
  File "D:\SashaDebugging\KiraFlake8Datetimez\.venv\Lib\site-packages\flake8\checker.py", line 220, in run_serial
    ).run_checks()
      ~~~~~~~~~~^^
  File "D:\SashaDebugging\KiraFlake8Datetimez\.venv\Lib\site-packages\flake8\checker.py", line 526, in run_checks
    self.run_ast_checks()
    ~~~~~~~~~~~~~~~~~~~^^
  File "D:\SashaDebugging\KiraFlake8Datetimez\.venv\Lib\site-packages\flake8\checker.py", line 428, in run_ast_checks
    for line_number, offset, text, _ in runner:
                                        ^^^^^^
  File "D:\SashaDebugging\KiraFlake8Datetimez\.venv\Lib\site-packages\flake8_datetimez.py", line 44, in run
    visitor.visit(self.tree)
    ~~~~~~~~~~~~~^^^^^^^^^^^
  File "C:\Python314\Lib\ast.py", line 506, in visit
    return visitor(node)
  File "C:\Python314\Lib\ast.py", line 514, in generic_visit
    self.visit(item)
    ~~~~~~~~~~^^^^^^
  File "C:\Python314\Lib\ast.py", line 506, in visit
    return visitor(node)
  File "C:\Python314\Lib\ast.py", line 516, in generic_visit
    self.visit(value)
    ~~~~~~~~~~^^^^^^^
  File "C:\Python314\Lib\ast.py", line 506, in visit
    return visitor(node)
  File "C:\Python314\Lib\ast.py", line 516, in generic_visit
    self.visit(value)
    ~~~~~~~~~~^^^^^^^
  File "C:\Python314\Lib\ast.py", line 506, in visit
    return visitor(node)
  File "D:\SashaDebugging\KiraFlake8Datetimez\.venv\Lib\site-packages\flake8_datetimez.py", line 106, in visit_Call
    and not (isinstance(tz_keyword.value, ast.NameConstant)
                                          ^^^^^^^^^^^^^^^^
AttributeError: module 'ast' has no attribute 'NameConstant'
```

##### 2.5.2. After the pull request

No errors and warnings.

### 3. Failed tests

Note that all your tests failed on my Windows. I got this problem for the original and modified code. When I ran commands `python -m unittest test_datetimez.py` and `pytest test_datetimez.py`, I got errors `PermissionError: [Errno 13] Permission denied`. The part of my traceback:

```python
________________________________________________________________________________________________________ TestDateTimeZ.test_DTZ012 _________________________________________________________________________________________________________

self = <test_datetimez.TestDateTimeZ testMethod=test_DTZ012>

    def test_DTZ012(self):
>       errors = self.write_file_and_run_checker(
            'datetime.date.fromtimestamp(1234)'
        )

test_datetimez.py:261:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
test_datetimez.py:18: in write_file_and_run_checker
    return list(checker.run())
           ^^^^^^^^^^^^^^^^^^^
flake8_datetimez.py:34: in run
    self.lines = pycodestyle.readlines(self.filename)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
C:\Python314\Lib\site-packages\pycodestyle.py:1747: in readlines
    with tokenize.open(filename) as f:
         ^^^^^^^^^^^^^^^^^^^^^^^
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

filename = 'C:\\Users\\SASHAC~2\\AppData\\Local\\Temp\\tmp20age3g3'

    def open(filename):
        """Open a file in read only mode using the encoding detected by
        detect_encoding().
        """
>       buffer = _builtin_open(filename, 'rb')
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E       PermissionError: [Errno 13] Permission denied: 'C:\\Users\\SASHAC~2\\AppData\\Local\\Temp\\tmp20age3g3'

C:\Python314\Lib\tokenize.py:455: PermissionError
__________________________________________________________________________________________________ TestDateTimeZ.test_DTZ012_unqualified ___________________________________________________________________________________________________

self = <test_datetimez.TestDateTimeZ testMethod=test_DTZ012_unqualified>

    def test_DTZ012_unqualified(self):
>       errors = self.write_file_and_run_checker(
            'date.fromtimestamp(1234)'
        )

test_datetimez.py:267:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
test_datetimez.py:18: in write_file_and_run_checker
    return list(checker.run())
           ^^^^^^^^^^^^^^^^^^^
flake8_datetimez.py:34: in run
    self.lines = pycodestyle.readlines(self.filename)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
C:\Python314\Lib\site-packages\pycodestyle.py:1747: in readlines
    with tokenize.open(filename) as f:
         ^^^^^^^^^^^^^^^^^^^^^^^
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

filename = 'C:\\Users\\SASHAC~2\\AppData\\Local\\Temp\\tmpx5232lq5'

    def open(filename):
        """Open a file in read only mode using the encoding detected by
        detect_encoding().
        """
>       buffer = _builtin_open(filename, 'rb')
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E       PermissionError: [Errno 13] Permission denied: 'C:\\Users\\SASHAC~2\\AppData\\Local\\Temp\\tmpx5232lq5'

C:\Python314\Lib\tokenize.py:455: PermissionError
========================================================================================================= short test summary info ========================================================================================================== FAILED test_datetimez.py::TestDateTimeZ::test_DTZ001_args_good - PermissionError: [Errno 13] Permission denied: 'C:\\Users\\SASHAC~2\\AppData\\Local\\Temp\\tmpowz5_pyp'
FAILED test_datetimez.py::TestDateTimeZ::test_DTZ001_kwargs_good - PermissionError: [Errno 13] Permission denied: 'C:\\Users\\SASHAC~2\\AppData\\Local\\Temp\\tmpf2ti6mm2'
FAILED test_datetimez.py::TestDateTimeZ::test_DTZ001_no_args - PermissionError: [Errno 13] Permission denied: 'C:\\Users\\SASHAC~2\\AppData\\Local\\Temp\\tmp7ubijhit'
FAILED test_datetimez.py::TestDateTimeZ::test_DTZ001_no_args_unqualified - PermissionError: [Errno 13] Permission denied: 'C:\\Users\\SASHAC~2\\AppData\\Local\\Temp\\tmp7m9zixsp'
FAILED test_datetimez.py::TestDateTimeZ::test_DTZ001_no_kwargs - PermissionError: [Errno 13] Permission denied: 'C:\\Users\\SASHAC~2\\AppData\\Local\\Temp\\tmp43j1oa9q'
FAILED test_datetimez.py::TestDateTimeZ::test_DTZ001_none_args - PermissionError: [Errno 13] Permission denied: 'C:\\Users\\SASHAC~2\\AppData\\Local\\Temp\\tmpwir85e_2'
FAILED test_datetimez.py::TestDateTimeZ::test_DTZ001_none_kwargs - PermissionError: [Errno 13] Permission denied: 'C:\\Users\\SASHAC~2\\AppData\\Local\\Temp\\tmp1pnltsp1'
FAILED test_datetimez.py::TestDateTimeZ::test_DTZ002 - PermissionError: [Errno 13] Permission denied: 'C:\\Users\\SASHAC~2\\AppData\\Local\\Temp\\tmpc3xck7qe'
FAILED test_datetimez.py::TestDateTimeZ::test_DTZ002_unqualified - PermissionError: [Errno 13] Permission denied: 'C:\\Users\\SASHAC~2\\AppData\\Local\\Temp\\tmprlrowh2s'
FAILED test_datetimez.py::TestDateTimeZ::test_DTZ003 - PermissionError: [Errno 13] Permission denied: 'C:\\Users\\SASHAC~2\\AppData\\Local\\Temp\\tmplua4cqce'
FAILED test_datetimez.py::TestDateTimeZ::test_DTZ003_unqualified - PermissionError: [Errno 13] Permission denied: 'C:\\Users\\SASHAC~2\\AppData\\Local\\Temp\\tmp6hg6gphk'
FAILED test_datetimez.py::TestDateTimeZ::test_DTZ004 - PermissionError: [Errno 13] Permission denied: 'C:\\Users\\SASHAC~2\\AppData\\Local\\Temp\\tmp_iov7n3k'
FAILED test_datetimez.py::TestDateTimeZ::test_DTZ004_unqualified - PermissionError: [Errno 13] Permission denied: 'C:\\Users\\SASHAC~2\\AppData\\Local\\Temp\\tmp6f2_mox8'
FAILED test_datetimez.py::TestDateTimeZ::test_DTZ005_args_good - PermissionError: [Errno 13] Permission denied: 'C:\\Users\\SASHAC~2\\AppData\\Local\\Temp\\tmp135zv4l2'
FAILED test_datetimez.py::TestDateTimeZ::test_DTZ005_keywords_good - PermissionError: [Errno 13] Permission denied: 'C:\\Users\\SASHAC~2\\AppData\\Local\\Temp\\tmpaq776qpp'
FAILED test_datetimez.py::TestDateTimeZ::test_DTZ005_no_args - PermissionError: [Errno 13] Permission denied: 'C:\\Users\\SASHAC~2\\AppData\\Local\\Temp\\tmp4x0jnmef'
FAILED test_datetimez.py::TestDateTimeZ::test_DTZ005_no_args_unqualified - PermissionError: [Errno 13] Permission denied: 'C:\\Users\\SASHAC~2\\AppData\\Local\\Temp\\tmpf97vw26x'
FAILED test_datetimez.py::TestDateTimeZ::test_DTZ005_none_args - PermissionError: [Errno 13] Permission denied: 'C:\\Users\\SASHAC~2\\AppData\\Local\\Temp\\tmpgudvc68b'
FAILED test_datetimez.py::TestDateTimeZ::test_DTZ005_none_keywords - PermissionError: [Errno 13] Permission denied: 'C:\\Users\\SASHAC~2\\AppData\\Local\\Temp\\tmpgeoa8p5j'
FAILED test_datetimez.py::TestDateTimeZ::test_DTZ005_wrong_keywords - PermissionError: [Errno 13] Permission denied: 'C:\\Users\\SASHAC~2\\AppData\\Local\\Temp\\tmpllzmqw61'
FAILED test_datetimez.py::TestDateTimeZ::test_DTZ006_args_good - PermissionError: [Errno 13] Permission denied: 'C:\\Users\\SASHAC~2\\AppData\\Local\\Temp\\tmpu7mxv7q_'
FAILED test_datetimez.py::TestDateTimeZ::test_DTZ006_keywords_good - PermissionError: [Errno 13] Permission denied: 'C:\\Users\\SASHAC~2\\AppData\\Local\\Temp\\tmpe9xc7kf4'
FAILED test_datetimez.py::TestDateTimeZ::test_DTZ006_no_args - PermissionError: [Errno 13] Permission denied: 'C:\\Users\\SASHAC~2\\AppData\\Local\\Temp\\tmpxhsgu4bc'
FAILED test_datetimez.py::TestDateTimeZ::test_DTZ006_no_args_unqualified - PermissionError: [Errno 13] Permission denied: 'C:\\Users\\SASHAC~2\\AppData\\Local\\Temp\\tmpz4r_mfnh'
FAILED test_datetimez.py::TestDateTimeZ::test_DTZ006_none_args - PermissionError: [Errno 13] Permission denied: 'C:\\Users\\SASHAC~2\\AppData\\Local\\Temp\\tmpt7wk6gk1'
FAILED test_datetimez.py::TestDateTimeZ::test_DTZ006_none_keywords - PermissionError: [Errno 13] Permission denied: 'C:\\Users\\SASHAC~2\\AppData\\Local\\Temp\\tmpm1epjejo'
FAILED test_datetimez.py::TestDateTimeZ::test_DTZ006_wrong_keywords - PermissionError: [Errno 13] Permission denied: 'C:\\Users\\SASHAC~2\\AppData\\Local\\Temp\\tmpoyl5721h'
FAILED test_datetimez.py::TestDateTimeZ::test_DTZ007_bad_format - PermissionError: [Errno 13] Permission denied: 'C:\\Users\\SASHAC~2\\AppData\\Local\\Temp\\tmpbtlmrupk'
FAILED test_datetimez.py::TestDateTimeZ::test_DTZ007_good_astimezone - PermissionError: [Errno 13] Permission denied: 'C:\\Users\\SASHAC~2\\AppData\\Local\\Temp\\tmp9cpk0tsr'
FAILED test_datetimez.py::TestDateTimeZ::test_DTZ007_good_format - PermissionError: [Errno 13] Permission denied: 'C:\\Users\\SASHAC~2\\AppData\\Local\\Temp\\tmpnpiqem9i'
FAILED test_datetimez.py::TestDateTimeZ::test_DTZ007_good_replace - PermissionError: [Errno 13] Permission denied: 'C:\\Users\\SASHAC~2\\AppData\\Local\\Temp\\tmp12k0ezgq'
FAILED test_datetimez.py::TestDateTimeZ::test_DTZ007_no_replace_or_astimezone - PermissionError: [Errno 13] Permission denied: 'C:\\Users\\SASHAC~2\\AppData\\Local\\Temp\\tmpe0tfe997'
FAILED test_datetimez.py::TestDateTimeZ::test_DTZ007_no_replace_or_astimezone_unqualified - PermissionError: [Errno 13] Permission denied: 'C:\\Users\\SASHAC~2\\AppData\\Local\\Temp\\tmpgm4s1n39'
FAILED test_datetimez.py::TestDateTimeZ::test_DTZ007_none_replace - PermissionError: [Errno 13] Permission denied: 'C:\\Users\\SASHAC~2\\AppData\\Local\\Temp\\tmpujkek8op'
FAILED test_datetimez.py::TestDateTimeZ::test_DTZ007_wrong_replace - PermissionError: [Errno 13] Permission denied: 'C:\\Users\\SASHAC~2\\AppData\\Local\\Temp\\tmpgz5hh17h'
FAILED test_datetimez.py::TestDateTimeZ::test_DTZ011 - PermissionError: [Errno 13] Permission denied: 'C:\\Users\\SASHAC~2\\AppData\\Local\\Temp\\tmpls89_qks'
FAILED test_datetimez.py::TestDateTimeZ::test_DTZ011_unqualified - PermissionError: [Errno 13] Permission denied: 'C:\\Users\\SASHAC~2\\AppData\\Local\\Temp\\tmp3stywqhy'
FAILED test_datetimez.py::TestDateTimeZ::test_DTZ012 - PermissionError: [Errno 13] Permission denied: 'C:\\Users\\SASHAC~2\\AppData\\Local\\Temp\\tmp20age3g3'
FAILED test_datetimez.py::TestDateTimeZ::test_DTZ012_unqualified - PermissionError: [Errno 13] Permission denied: 'C:\\Users\\SASHAC~2\\AppData\\Local\\Temp\\tmpx5232lq5'
============================================================================================================ 39 failed in 1.79s ============================================================================================================
```

### 4. Testing environment

1. Windows 11 [Version 10.0.22621.3085]
1. Python 3.14.0
1. Pipenv 2025.0.4
1. flake8 7.3.0
1. flake8-datetimez 20.10.0

Thanks.